### PR TITLE
Soft delete accounts & activate users; API and query updates

### DIFF
--- a/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.Accounts/Application/Commands/DeleteAccountCommand.cs
+++ b/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.Accounts/Application/Commands/DeleteAccountCommand.cs
@@ -1,0 +1,54 @@
+﻿using AutoMapper;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using PersonalFinance.Services.Accounts.Application.Common;
+using PersonalFinance.Services.Accounts.Application.DataTransferObjects.Response;
+using PersonalFinance.Services.Accounts.Application.DTOs;
+using PersonalFinance.Services.Accounts.Application.Mappings;
+using PersonalFinance.Services.Accounts.Infrastructure.Data;
+
+namespace PersonalFinance.Services.Accounts.Application.Commands
+{
+    public class DeleteAccountCommand : IRequest<ApiResponse<AccountTransferObject>>
+    {
+        public Guid AccountId { get; set; }
+        public Guid UserId { get; set; }
+
+        public DeleteAccountCommand(Guid accountId, Guid userId)
+        {
+            AccountId = accountId;
+            UserId = userId;
+        }
+    }
+
+    public class DeleteAccountCommandHandler : BaseRequestHandler<DeleteAccountCommand, ApiResponse<AccountTransferObject>>
+    {
+        public DeleteAccountCommandHandler(AccountDbContext context, ILogger<DeleteAccountCommandHandler> logger, IMapper mapper)
+            : base(context, logger, mapper)
+        {
+        }
+
+        public async override Task<ApiResponse<AccountTransferObject>> Handle(DeleteAccountCommand request, CancellationToken cancellationToken)
+        {
+
+            var account = await Context.Accounts.FindAsync(request.AccountId);
+            
+            if (account is null && !account.IsActive)
+            {
+                Logger.LogError("Account with account id {AccountId} does not exist for user {UserId}", request.AccountId, request.UserId);
+                return ApiResponse<AccountTransferObject>.ErrorResult("Account does not exist");
+            }
+
+            //Mark the account as inactive instead of deleting it from the database
+
+            account.TogggleActiveStatus(false);
+
+            await Context.SaveChangesAsync();
+            var accountTransferObject = account?.ToDto(Mapper);
+
+            // Implementation logic for setting the default account
+            // This is a placeholder as the actual logic is not provided in the original code snippet.
+            return await Task.FromResult(ApiResponse<AccountTransferObject>.SuccessResult(accountTransferObject));
+        }
+    }
+}

--- a/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.Accounts/Application/Commands/SetDefaultAccountCommand.cs
+++ b/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.Accounts/Application/Commands/SetDefaultAccountCommand.cs
@@ -29,8 +29,6 @@ namespace PersonalFinance.Services.Accounts.Application.Commands
 
         public async override Task<ApiResponse<AccountTransferObject>> Handle(SetDefaultAccountCommand request, CancellationToken cancellationToken)
         {
-
-
             var accounts = await Context.Accounts.Where(x => x.UserId == request.UserId).ToListAsync();
             
             if (!accounts.Any())

--- a/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.Accounts/Application/Commands/UpdateBalanceCommand.cs
+++ b/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.Accounts/Application/Commands/UpdateBalanceCommand.cs
@@ -2,6 +2,7 @@
 using MediatR;
 using PersonalFinance.Services.Accounts.Application.Common;
 using PersonalFinance.Services.Accounts.Application.DataTransferObjects.Response;
+using PersonalFinance.Services.Accounts.Application.DTOs;
 using PersonalFinance.Services.Accounts.Infrastructure.Data;
 using PersonalFinance.Shared.Common.Domain.ValueObjects;
 
@@ -29,23 +30,31 @@ namespace PersonalFinance.Services.Accounts.Application.Commands
 
         public override async Task<ApiResponse<bool>> Handle(UpdateBalanceCommand request, CancellationToken token)
         {
-            var account = await Context.Accounts.FindAsync(request.Id);
-
-            if (account == null)
+            try
             {
-                Logger.LogError("Account with ID {ID} not found", request.Id);
-                return ApiResponse<bool>.ErrorResult("Account not found");
+                var account = await Context.Accounts.FindAsync(request.Id);
+
+                if (account == null)
+                {
+                    Logger.LogError("Account with ID {ID} not found", request.Id);
+                    return ApiResponse<bool>.ErrorResult("Account not found");
+                }
+
+                if (request.IsDeposit)
+                    account.Deposit(request.Money);
+                else
+                    account.Withdraw(request.Money);
+
+                await Context.SaveChangesAsync();
+
+                Logger.LogInformation("Account balance for account id: {Id}", request.Id);
+                return ApiResponse<bool>.SuccessResult(true, "Account balance updated successfully");
             }
-
-            if (request.IsDeposit)
-                account.Deposit(request.Money);
-            else
-                account.Withdraw(request.Money);
-
-            await Context.SaveChangesAsync();
-
-            Logger.LogInformation("Account balance for account id: {Id}", request.Id);
-            return ApiResponse<bool>.SuccessResult(true, "Account balance updated successfully");
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Error in {action} the account ID: {Id}", request.IsDeposit ? "depositing" : "withdrawing", request.Id);
+                return ApiResponse<bool>.ErrorResult($"An error occurred while creating the account, {ex.Message}");
+            }
         }
     }
 }

--- a/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.Accounts/Application/Queries/GetAccountByUserIdQuery.cs
+++ b/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.Accounts/Application/Queries/GetAccountByUserIdQuery.cs
@@ -28,7 +28,11 @@ namespace PersonalFinance.Services.Accounts.Application.Queries
 
         public override async Task<ApiResponse<List<AccountTransferObject>>> Handle(GetAccountByUserIdQuery request, CancellationToken cancellationToken)
         {
-            var accounts = await Context.Accounts.Where(a => a.UserId == request.UserId).ToListAsync();
+            var accounts = await Context.Accounts
+                            .Where(a => a.UserId == request.UserId && a.IsActive)
+                            .OrderByDescending(a => a.IsDefault)
+                            .ThenBy(a => a.CreatedAt)
+                            .ToListAsync();
 
             if (!accounts.Any())
             {

--- a/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.Accounts/Controllers/AccountsController.cs
+++ b/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.Accounts/Controllers/AccountsController.cs
@@ -324,5 +324,35 @@ namespace PersonalFinance.Services.Accounts.Controllers
                 return ApiResponse<AccountTransferObject>.ErrorResult("An internal error occurred while setting default account");
             }
         }
+
+        /// <summary>
+        /// Marks the account as inactive instead of deleting it permanently
+        /// </summary>
+        /// <param name="userId"></param>
+        /// <param name="accountId"></param>
+        /// <returns>Returns the account object which is marked inactive</returns>
+        [HttpDelete("{userId:guid}/{accountId:guid}")]
+        [ProducesResponseType(typeof(ApiResponse<AccountTransferObject>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ApiResponse<AccountTransferObject>), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(ApiResponse<AccountTransferObject>), StatusCodes.Status404NotFound)]
+        public async Task<ActionResult<ApiResponse<AccountTransferObject>>> DeleteAccount(Guid userId, Guid accountId)
+        {
+            try
+            {
+                var command = new DeleteAccountCommand(accountId, userId);
+
+                var result = await _mediator.Send(command);
+
+                if (result.Success)
+                    return Ok(result);
+
+                return BadRequest(result);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error deleting the account for user: {UserId} with account id: {AccountId}", userId, accountId);
+                return ApiResponse<AccountTransferObject>.ErrorResult("An internal error occurred while deleting the account");
+            }
+        }
     }
 }

--- a/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.Accounts/Domain/Entities/Account.cs
+++ b/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.Accounts/Domain/Entities/Account.cs
@@ -63,6 +63,12 @@ namespace PersonalFinance.Services.Accounts.Domain.Entities
             AddDomainEvent(new DefaultAccountChnagedEvent(UserId, Name, IsDefault));
         }
 
+        public void TogggleActiveStatus(bool isActive)
+        {
+            IsActive = isActive;
+            AddDomainEvent(new AccountStatusChangedEvent(UserId, Id, Name, IsActive));
+        }
+
         public void AddDescription(string description)
         {
             if (string.IsNullOrWhiteSpace(description))

--- a/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.Accounts/Domain/Events/AccountEvents.cs
+++ b/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.Accounts/Domain/Events/AccountEvents.cs
@@ -1,4 +1,5 @@
-﻿using PersonalFinance.Services.Accounts.Domain.Entities;
+﻿using Microsoft.Identity.Client;
+using PersonalFinance.Services.Accounts.Domain.Entities;
 using PersonalFinance.Shared.Common.Domain;
 using PersonalFinance.Shared.Common.Domain.ValueObjects;
 
@@ -50,5 +51,21 @@ namespace PersonalFinance.Services.Accounts.Domain.Events
         public Guid UserId { get; }
         public string Name { get; }
         public bool IsDefault { get; }
+    }
+
+    public class AccountStatusChangedEvent : DomainEvent
+    {
+        public AccountStatusChangedEvent(Guid userId, Guid accountId, string name, bool isActive)
+        {
+            UserId = userId;
+            AccountId = accountId;
+            Name = name ?? throw new ArgumentNullException(nameof(name), "Name cannot be null");
+            IsActive = isActive;
+        }
+
+        public Guid UserId { get; }
+        public Guid AccountId { get; }
+        public string Name { get; }
+        public bool IsActive { get; }
     }
 }

--- a/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Application/Commands/ActivateUserCommand.cs
+++ b/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Application/Commands/ActivateUserCommand.cs
@@ -1,0 +1,49 @@
+﻿using AutoMapper;
+using MediatR;
+using PersonalFinance.Services.UserManagement.Application.Common;
+using PersonalFinance.Services.UserManagement.Application.DataTransferObjects.Response;
+using PersonalFinance.Services.UserManagement.Infrastructure.Data;
+
+namespace PersonalFinance.Services.UserManagement.Application.Commands
+{
+    public class ActivateUserCommand : IRequest<ApiResponse<bool>>
+    {
+        public Guid UserId { get; set; }
+        public ActivateUserCommand(Guid userId)
+        {
+            UserId = userId;
+        }
+    }
+
+    public class ActivateUserHandler : BaseRequestHandler<ActivateUserCommand, ApiResponse<bool>>
+    {
+        public ActivateUserHandler(UserManagementDbContext context, ILogger<ActivateUserHandler> logger, IMapper mapper) : base(context, logger, mapper)
+        {
+        }
+
+        public override async Task<ApiResponse<bool>> Handle(ActivateUserCommand request, CancellationToken cancellationToken)
+        {
+            try
+            {
+
+                var user = await UserExistAsync(request.UserId, cancellationToken: cancellationToken, ignoreQueryfilter:true);
+
+                if (user == null)
+                {
+                    return ApiResponse<bool>.ErrorResult("User not found");
+                }
+
+                user.Activate("User activated by request");
+                await Context.SaveChangesAsync(cancellationToken);
+
+                Logger.LogInformation("User with ID {UserId} activated successfully", request.UserId);
+                return ApiResponse<bool>.SuccessResult(true, "User activated successfully");
+            }
+            catch (Exception ex)
+            {
+                Logger.LogInformation("User with ID {UserId} not activated!", request.UserId);
+                return ApiResponse<bool>.ErrorResult($"An error occurred while activating the user: {ex.Message}");
+            }
+        }
+    }
+}

--- a/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Application/Common/BaseRequestHandler.cs
+++ b/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Application/Common/BaseRequestHandler.cs
@@ -59,7 +59,7 @@ namespace PersonalFinance.Services.UserManagement.Application.Common
         /// <returns>A task that represents the asynchronous operation. The task result contains true if the email exists; otherwise, false.</returns>  
         protected async Task<bool> EmailExistAsync(string email, CancellationToken cancellationToken = default)
         {
-            return await Context.Users
+            return await Context.Users.IgnoreQueryFilters()
                 .AnyAsync(u => u.Email.Value == email.ToLower(), cancellationToken);
         }
 
@@ -81,9 +81,9 @@ namespace PersonalFinance.Services.UserManagement.Application.Common
         /// <param name="userId">The username to fidn the user.</param>  
         /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>  
         /// <returns>A task that represents the asynchronous operation. The task result contains user object if the user exists; otherwise, null.</returns>  
-        protected async Task<User?> UserExistAsync(Guid userId, bool includeChilds = false, CancellationToken cancellationToken = default)
+        protected async Task<User?> UserExistAsync(Guid userId, bool includeChilds = false, CancellationToken cancellationToken = default, bool ignoreQueryfilter = false)
         {
-            IQueryable<User> query = Context.Users;
+            IQueryable<User> query = ignoreQueryfilter ? Context.Users.IgnoreQueryFilters() : Context.Users;
 
             if (includeChilds)
             {

--- a/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Application/Queries/GetUserByEmailQuery.cs
+++ b/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Application/Queries/GetUserByEmailQuery.cs
@@ -26,11 +26,12 @@ namespace PersonalFinance.Services.UserManagement.Application.Queries
         }
         public override async Task<ApiResponse<UserTransferObject>> Handle(GetUserByEmailQuery request, CancellationToken cancellationToken)
         {
-            var user = await Context.Users
+            var user = await Context.Users.IgnoreQueryFilters()
                 .Include(u => u.Profile)
                 .Include(u => u.UserRoles)
                     .ThenInclude(ur => ur.Role)
                 .FirstOrDefaultAsync(u => u.Email.Value == request.Email.Value, cancellationToken);
+
             if (user == null)
             {
                 Logger.LogError("User with email {Email} not found", request.Email.Value);

--- a/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Application/Queries/GetUserByIdQuery.cs
+++ b/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Application/Queries/GetUserByIdQuery.cs
@@ -28,11 +28,8 @@ namespace PersonalFinance.Services.UserManagement.Application.Queries
 
         public override async Task<ApiResponse<UserTransferObject>> Handle(GetUserByIdQuery request, CancellationToken cancellationToken)
         {
-            var user = await Context.Users
-                .Include(u => u.Profile)
-                .Include(u => u.UserRoles)
-                    .ThenInclude(ur => ur.Role)
-                .FirstOrDefaultAsync(u => u.Id == request.UserId, cancellationToken);
+
+            var user = await UserExistAsync(request.UserId, includeChilds:true, ignoreQueryfilter : true);
 
             if (user == null)
             {

--- a/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Application/Queries/GetUsersQuery.cs
+++ b/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Application/Queries/GetUsersQuery.cs
@@ -39,7 +39,8 @@ namespace PersonalFinance.Services.UserManagement.Application.Queries
                     .Include(u => u.Profile)
                     .Include(u => u.UserRoles)
                         .ThenInclude(ur => ur.Role)
-                    .OrderBy(u => u.CreatedAt)
+                    .OrderByDescending(u => u.IsActive)
+                    .ThenBy(u => u.CreatedAt)
                     .Skip((request.PageNumber - 1) * request.PageSize)
                     .Take(request.PageSize)
                     .ToListAsync(cancellationToken);

--- a/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Controllers/UserManagementController.cs
+++ b/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Controllers/UserManagementController.cs
@@ -257,6 +257,35 @@ namespace PersonalFinance.Services.UserManagement.Controllers
         }
 
         /// <summary>
+        /// Activate the user after deleting
+        /// </summary>
+        /// <param name="id">User ID</param>
+        /// <returns>Success confirmation</returns>
+        [HttpPut("{id:guid}")]
+        [ProducesResponseType(typeof(ApiResponse<bool>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ApiResponse<bool>), StatusCodes.Status404NotFound)]
+        public async Task<ActionResult<ApiResponse<bool>>> ActivateUser(Guid id)
+        {
+            try
+            {
+                var command = new ActivateUserCommand(id);
+                var result = await _mediator.Send(command);
+
+                if (result.Success)
+                {
+                    return Ok(result);
+                }
+
+                return NotFound(result);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error activating user: {UserId}", id);
+                return StatusCode(500, ApiResponse<bool>.ErrorResult("An internal error occurred"));
+            }
+        }
+
+        /// <summary>
         /// Soft delete user
         /// </summary>
         /// <param name="id">User ID</param>

--- a/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Domain/Entities/User.cs
+++ b/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Domain/Entities/User.cs
@@ -87,6 +87,12 @@ namespace PersonalFinance.Services.UserManagement.Domain.Entities
             Profile = userProfile ?? throw new ArgumentNullException(nameof(userProfile));
         }
 
+        public void Activate(string reason)
+        {
+            IsActive = true;
+            AddDomainEvent(new UserDeactivatedEvent(Id, reason));
+        }
+
         public void Deactivate(string reason)
         {
             // Logic to deactivate user, e.g., setting a flag or removing roles

--- a/json_schemas/Gateway Accounts Schema.json
+++ b/json_schemas/Gateway Accounts Schema.json
@@ -450,6 +450,68 @@
           }
         }
       }
+    },
+    "/api/Accounts/{userId}/{accountId}": {
+      "delete": {
+        "tags": [
+          "Accounts"
+        ],
+        "summary": "Marks the account as inactive instead of deleting it permanently",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "accountId",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountTransferObjectApiResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountTransferObjectApiResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountTransferObjectApiResponse"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {

--- a/json_schemas/Gateway User Schema.json
+++ b/json_schemas/Gateway User Schema.json
@@ -106,6 +106,46 @@
           }
         }
       },
+      "put": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Activate the user after deleting",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "User ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BooleanApiResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BooleanApiResponse"
+                }
+              }
+            }
+          }
+        }
+      },
       "delete": {
         "tags": [
           "Users"


### PR DESCRIPTION
- Add DeleteAccountCommand to soft-delete (deactivate) accounts
- Add ActivateUserCommand to reactivate users
- Expose new DELETE /api/Accounts/{userId}/{accountId} and PUT /api/Users/{id} endpoints
- Update OpenAPI schemas for new endpoints
- Use IgnoreQueryFilters in queries to support soft-deleted entities
- Return only active accounts in GetAccountByUserIdQuery; order users by IsActive
- Improve error handling and logging in command handlers
- Refactor and fix minor issues in handlers and entity methods