### PR TITLE
Add Google OAuth2 login and refresh token support

### DIFF
--- a/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Application/Commands/GoogleLoginCommand.cs
+++ b/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Application/Commands/GoogleLoginCommand.cs
@@ -1,0 +1,119 @@
+using AutoMapper;
+
+using Google.Apis.Auth;
+
+using MediatR;
+
+using Microsoft.EntityFrameworkCore;
+
+using PersonalFinance.Services.UserManagement.Application.Common;
+using PersonalFinance.Services.UserManagement.Application.DataTransferObjects.Response;
+using PersonalFinance.Services.UserManagement.Application.Mappings;
+using PersonalFinance.Services.UserManagement.Application.Services;
+using PersonalFinance.Services.UserManagement.Domain.Entities;
+using PersonalFinance.Services.UserManagement.Infrastructure.Data;
+
+namespace PersonalFinance.Services.UserManagement.Application.Commands
+{
+    public class GoogleLoginCommand : IRequest<ApiResponse<LoginResponse>>
+    {
+        public string IdToken { get; set; } = string.Empty;
+        public string? IpAddress { get; set; }
+    }
+
+    public class GoogleLoginCommandHandler : BaseCommandHandler<GoogleLoginCommand, ApiResponse<LoginResponse>>
+    {
+        private readonly ITokenService _tokenService;
+        private readonly IConfiguration _configuration;
+
+        public GoogleLoginCommandHandler(
+            UserManagementDbContext context,
+            IPasswordHasher passwordHasher,
+            ITokenService tokenService,
+            IMapper mapper,
+            IConfiguration configuration,
+            ILogger<GoogleLoginCommandHandler> logger) : base(context, logger, mapper, passwordHasher)
+        {
+            _tokenService = tokenService;
+            _configuration = configuration;
+        }
+
+        public override async Task<ApiResponse<LoginResponse>> Handle(GoogleLoginCommand request, CancellationToken cancellationToken)
+        {
+            try
+            {
+                Logger.LogInformation("Attempting Google login");
+
+                var settings = new GoogleJsonWebSignature.ValidationSettings
+                {
+                    Audience = new[] { _configuration["GoogleSettings:ClientId"] }
+                };
+
+                var payload = await GoogleJsonWebSignature.ValidateAsync(request.IdToken, settings);
+
+                if (payload == null)
+                {
+                    return ApiResponse<LoginResponse>.ErrorResult("Invalid Google token");
+                }
+
+                var user = await Context.Users
+                    .Include(u => u.UserRoles)
+                        .ThenInclude(ur => ur.Role)
+                    .FirstOrDefaultAsync(u => u.Email.Value == payload.Email.ToLower() || u.GoogleId == payload.Subject, cancellationToken);
+
+                bool isNewUser = false;
+
+                if (user == null)
+                {
+                    // Register new user
+                    isNewUser = true;
+                    user = new User(payload.Email, payload.Email, payload.GivenName ?? "", payload.FamilyName ?? "");
+                    user.SetGoogleId(payload.Subject);
+                    user.ConfirmEmail();
+
+                    var userRole = await Context.Roles.FirstOrDefaultAsync(r => r.Name == "User", cancellationToken);
+                    if (userRole != null)
+                    {
+                        user.AddRole(userRole);
+                    }
+
+                    Context.Users.Add(user);
+                    await Context.SaveChangesAsync(cancellationToken);
+                }
+                else if (string.IsNullOrEmpty(user.GoogleId))
+                {
+                    // Link existing user to Google
+                    user.SetGoogleId(payload.Subject);
+                    await Context.SaveChangesAsync(cancellationToken);
+                }
+
+                var roles = user.UserRoles.Select(ur => ur.Role.Name).ToList();
+                var accessToken = _tokenService.CreateToken(user, roles);
+                var refreshToken = _tokenService.GenerateRefreshToken();
+
+                // Insert refresh token directly — bypasses User's RowVersion concurrency check
+                var refreshTokenEntity = new Domain.Entities.RefreshToken(refreshToken, DateTime.UtcNow.AddDays(7), user.Id, request.IpAddress);
+                Context.RefreshTokens.Add(refreshTokenEntity);
+                await Context.SaveChangesAsync(cancellationToken);
+
+                var loginResponse = new LoginResponse
+                {
+                    User = user.ToDto(Mapper),
+                    AccessToken = accessToken,
+                    RefreshToken = refreshToken,
+                    ExpiresAt = DateTime.UtcNow.AddMinutes(int.Parse(_configuration["JwtSettings:ExpiryMinutes"] ?? "5")),
+                    Permissions = roles
+                };
+
+                Logger.LogInformation("Google login successful for email: {Email}", payload.Email);
+
+                return ApiResponse<LoginResponse>.SuccessResult(loginResponse, "Login successful");
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Error during Google login");
+                return ApiResponse<LoginResponse>.ErrorResult($"An error occurred during Google login: {ex.Message}");
+            }
+        }
+    }
+}

--- a/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Application/Commands/LoginUserCommand.cs
+++ b/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Application/Commands/LoginUserCommand.cs
@@ -21,15 +21,18 @@ namespace PersonalFinance.Services.UserManagement.Application.Commands
     public class LoginUserCommandHandler : BaseCommandHandler<LoginUserCommand, ApiResponse<LoginResponse>>
     {
         private readonly ITokenService _tokenService;
+        private readonly IConfiguration _configuration;
 
         public LoginUserCommandHandler(
             UserManagementDbContext context,
             IPasswordHasher passwordHasher,
             ITokenService tokenService,
             IMapper mapper,
+            IConfiguration configuration,
             ILogger<LoginUserCommandHandler> logger) : base(context, logger, mapper, passwordHasher)
         {
             _tokenService = tokenService;
+            _configuration = configuration;
         }
 
         public override async Task<ApiResponse<LoginResponse>> Handle(LoginUserCommand request, CancellationToken cancellationToken)
@@ -38,7 +41,9 @@ namespace PersonalFinance.Services.UserManagement.Application.Commands
             {
                 Logger.LogInformation("Attempting login for email: {Email}", request.Email);
 
+                // Load user as read-only — we only need it for verification and token generation
                 var user = await Context.Users
+                    .AsNoTracking()
                     .Include(u => u.UserRoles)
                         .ThenInclude(ur => ur.Role)
                     .FirstOrDefaultAsync(u => u.Email.Value == request.Email.ToLower(), cancellationToken);
@@ -56,14 +61,21 @@ namespace PersonalFinance.Services.UserManagement.Application.Commands
                 }
 
                 var roles = user.UserRoles.Select(ur => ur.Role.Name).ToList();
-                var token = _tokenService.CreateToken(user, roles);
+                var accessToken = _tokenService.CreateToken(user, roles);
+                var refreshToken = _tokenService.GenerateRefreshToken();
+
+                // Insert refresh token directly — bypasses User's RowVersion concurrency check
+                var refreshTokenEntity = new Domain.Entities.RefreshToken(refreshToken, DateTime.UtcNow.AddDays(7), user.Id);
+                Context.RefreshTokens.Add(refreshTokenEntity);
+                await Context.SaveChangesAsync(cancellationToken);
 
                 var loginResponse = new LoginResponse
                 {
                     User = user.ToDto(Mapper),
-                    AccessToken = token,
-                    ExpiresAt = DateTime.UtcNow.AddMinutes(5), // Configured in settings but matching here for response
-                    Permissions = roles // In this context, roles are treated as permissions or base for them
+                    AccessToken = accessToken,
+                    RefreshToken = refreshToken,
+                    ExpiresAt = DateTime.UtcNow.AddMinutes(int.Parse(_configuration["JwtSettings:ExpiryMinutes"] ?? "5")),
+                    Permissions = roles
                 };
 
                 Logger.LogInformation("Login successful for email: {Email}", request.Email);

--- a/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Application/Commands/RefreshTokenCommand.cs
+++ b/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Application/Commands/RefreshTokenCommand.cs
@@ -1,0 +1,94 @@
+using AutoMapper;
+
+using MediatR;
+
+using Microsoft.EntityFrameworkCore;
+
+using PersonalFinance.Services.UserManagement.Application.Common;
+using PersonalFinance.Services.UserManagement.Application.DataTransferObjects.Response;
+using PersonalFinance.Services.UserManagement.Application.Mappings;
+using PersonalFinance.Services.UserManagement.Application.Services;
+using PersonalFinance.Services.UserManagement.Infrastructure.Data;
+
+namespace PersonalFinance.Services.UserManagement.Application.Commands
+{
+    public class RefreshTokenCommand : IRequest<ApiResponse<LoginResponse>>
+    {
+        public string AccessToken { get; set; } = string.Empty;
+        public string RefreshToken { get; set; } = string.Empty;
+        public string? IpAddress { get; set; }
+    }
+
+    public class RefreshTokenCommandHandler : BaseCommandHandler<RefreshTokenCommand, ApiResponse<LoginResponse>>
+    {
+        private readonly ITokenService _tokenService;
+        private readonly IConfiguration _configuration;
+
+        public RefreshTokenCommandHandler(
+            UserManagementDbContext context,
+            IPasswordHasher passwordHasher,
+            ITokenService tokenService,
+            IMapper mapper,
+            IConfiguration configuration,
+            ILogger<RefreshTokenCommandHandler> logger) : base(context, logger, mapper, passwordHasher)
+        {
+            _tokenService = tokenService;
+            _configuration = configuration;
+        }
+
+        public override async Task<ApiResponse<LoginResponse>> Handle(RefreshTokenCommand request, CancellationToken cancellationToken)
+        {
+            try
+            {
+                Logger.LogInformation("Attempting token refresh");
+
+                var user = await Context.Users
+                    .Include(u => u.UserRoles)
+                        .ThenInclude(ur => ur.Role)
+                    .Include(u => u.RefreshTokens)
+                    .FirstOrDefaultAsync(u => u.RefreshTokens.Any(t => t.Token == request.RefreshToken), cancellationToken);
+
+                if (user == null)
+                {
+                    return ApiResponse<LoginResponse>.ErrorResult("Invalid refresh token");
+                }
+
+                var refreshToken = user.RefreshTokens.Single(x => x.Token == request.RefreshToken);
+
+                if (!refreshToken.IsFullyActive)
+                {
+                    return ApiResponse<LoginResponse>.ErrorResult("Refresh token is inactive or expired");
+                }
+
+                // Token Rotation: Revoke current and issue new
+                var newRefreshTokenString = _tokenService.GenerateRefreshToken();
+                user.RevokeRefreshToken(request.RefreshToken, request.IpAddress, newRefreshTokenString);
+                user.AddRefreshToken(newRefreshTokenString, DateTime.UtcNow.AddDays(7), request.IpAddress);
+                user.RemoveOldRefreshTokens();
+
+                await Context.SaveChangesAsync(cancellationToken);
+
+                var roles = user.UserRoles.Select(ur => ur.Role.Name).ToList();
+                var newAccessToken = _tokenService.CreateToken(user, roles);
+
+                var loginResponse = new LoginResponse
+                {
+                    User = user.ToDto(Mapper),
+                    AccessToken = newAccessToken,
+                    RefreshToken = newRefreshTokenString,
+                    ExpiresAt = DateTime.UtcNow.AddMinutes(int.Parse(_configuration["JwtSettings:ExpiryMinutes"] ?? "5")),
+                    Permissions = roles
+                };
+
+                Logger.LogInformation("Token refresh successful for email: {Email}", user.Email.Value);
+
+                return ApiResponse<LoginResponse>.SuccessResult(loginResponse, "Token refreshed successfully");
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Error during token refresh");
+                return ApiResponse<LoginResponse>.ErrorResult($"An error occurred during token refresh: {ex.Message}");
+            }
+        }
+    }
+}

--- a/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Application/Services/ITokenService.cs
+++ b/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Application/Services/ITokenService.cs
@@ -5,5 +5,6 @@ namespace PersonalFinance.Services.UserManagement.Application.Services
     public interface ITokenService
     {
         string CreateToken(User user, IEnumerable<string> roles);
+        string GenerateRefreshToken();
     }
 }

--- a/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Controllers/AuthController.cs
+++ b/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Controllers/AuthController.cs
@@ -61,5 +61,65 @@ namespace PersonalFinance.Services.UserManagement.Controllers
 
             return CreatedAtAction(nameof(Register), new { id = result.Data?.Id }, result);
         }
+
+        /// <summary>
+        /// Authenticates a user using Google OAuth2.
+        /// </summary>
+        [HttpPost("google-login")]
+        [ProducesResponseType(typeof(ApiResponse<LoginResponse>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ApiResponse<LoginResponse>), StatusCodes.Status401Unauthorized)]
+        public async Task<IActionResult> GoogleLogin([FromBody] GoogleLoginRequest request)
+        {
+            var command = new GoogleLoginCommand
+            {
+                IdToken = request.IdToken,
+                IpAddress = HttpContext.Connection.RemoteIpAddress?.ToString()
+            };
+
+            var result = await _mediator.Send(command);
+
+            if (!result.Success)
+            {
+                return Unauthorized(result);
+            }
+
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Refreshes the access token using a refresh token.
+        /// </summary>
+        [HttpPost("refresh")]
+        [ProducesResponseType(typeof(ApiResponse<LoginResponse>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ApiResponse<LoginResponse>), StatusCodes.Status401Unauthorized)]
+        public async Task<IActionResult> Refresh([FromBody] RefreshTokenRequest request)
+        {
+            var command = new RefreshTokenCommand
+            {
+                AccessToken = request.AccessToken,
+                RefreshToken = request.RefreshToken,
+                IpAddress = HttpContext.Connection.RemoteIpAddress?.ToString()
+            };
+
+            var result = await _mediator.Send(command);
+
+            if (!result.Success)
+            {
+                return Unauthorized(result);
+            }
+
+            return Ok(result);
+        }
+    }
+
+    public class GoogleLoginRequest
+    {
+        public string IdToken { get; set; } = string.Empty;
+    }
+
+    public class RefreshTokenRequest
+    {
+        public string AccessToken { get; set; } = string.Empty;
+        public string RefreshToken { get; set; } = string.Empty;
     }
 }

--- a/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Domain/Entities/RefreshToken.cs
+++ b/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Domain/Entities/RefreshToken.cs
@@ -1,0 +1,40 @@
+using PersonalFinance.Shared.Common.Domain;
+
+namespace PersonalFinance.Services.UserManagement.Domain.Entities
+{
+    public class RefreshToken : BaseEntity
+    {
+        public string Token { get; private set; }
+        public DateTime ExpiresAt { get; private set; }
+        public bool IsExpired => DateTime.UtcNow >= ExpiresAt;
+        public string? CreatedByIp { get; private set; }
+        public DateTime? RevokedAt { get; private set; }
+        public string? RevokedByIp { get; private set; }
+        public string? ReplacedByToken { get; private set; }
+        public bool IsFullyActive => RevokedAt == null && !IsExpired;
+
+        public Guid UserId { get; private set; }
+        public User User { get; private set; } = null!;
+
+        private RefreshToken() { } // EF Core
+
+        public RefreshToken(string token, DateTime expiresAt, Guid userId, string? createdByIp = null)
+        {
+            Id = Guid.NewGuid();
+            Token = token ?? throw new ArgumentNullException(nameof(token));
+            ExpiresAt = expiresAt;
+            UserId = userId;
+            CreatedAt = DateTime.UtcNow;
+            CreatedByIp = createdByIp;
+            IsActive = true;
+        }
+
+        public void Revoke(string? revokedByIp = null, string? replacedByToken = null)
+        {
+            RevokedAt = DateTime.UtcNow;
+            RevokedByIp = revokedByIp;
+            ReplacedByToken = replacedByToken;
+            IsActive = false;
+        }
+    }
+}

--- a/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Domain/Entities/User.cs
+++ b/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Domain/Entities/User.cs
@@ -1,4 +1,4 @@
-﻿using PersonalFinance.Services.UserManagement.Domain.Events;
+using PersonalFinance.Services.UserManagement.Domain.Events;
 using PersonalFinance.Shared.Common.Domain;
 using PersonalFinance.Shared.Common.Domain.ValueObjects;
 
@@ -13,11 +13,13 @@ namespace PersonalFinance.Services.UserManagement.Domain.Entities
         public string LastName { get; private set; } = string.Empty;
         public bool IsEmailConfirmed { get; private set; } = false;
         public string? PhoneNumber { get; private set; }
+        public string? GoogleId { get; private set; }
         public DateTime? LastLoginAt { get; private set; }
 
         private User() { }
 
         private readonly List<UserRole> _userRoles = new();
+        private readonly List<RefreshToken> _refreshTokens = new();
 
         public User(string email, string userName, string firstName, string lastName)
         {
@@ -33,6 +35,7 @@ namespace PersonalFinance.Services.UserManagement.Domain.Entities
         // Navigation properties
         public UserProfile? Profile { get; private set; }
         public IReadOnlyCollection<UserRole> UserRoles => _userRoles.AsReadOnly();
+        public IReadOnlyCollection<RefreshToken> RefreshTokens => _refreshTokens.AsReadOnly();
 
         // Business methods
         public void UpdateProfile(string firstName, string lastName, string? phoneNumber)
@@ -100,5 +103,26 @@ namespace PersonalFinance.Services.UserManagement.Domain.Entities
             AddDomainEvent(new UserDeactivatedEvent(Id, reason));
         }
 
+        public void SetGoogleId(string googleId)
+        {
+            GoogleId = googleId;
+        }
+
+        public void AddRefreshToken(string token, DateTime expiresAt, string? createdByIp = null)
+        {
+            var refreshToken = new RefreshToken(token, expiresAt, Id, createdByIp);
+            _refreshTokens.Add(refreshToken);
+        }
+
+        public void RevokeRefreshToken(string token, string? revokedByIp = null, string? replacedByToken = null)
+        {
+            var refreshToken = _refreshTokens.FirstOrDefault(t => t.Token == token);
+            refreshToken?.Revoke(revokedByIp, replacedByToken);
+        }
+
+        public void RemoveOldRefreshTokens()
+        {
+            _refreshTokens.RemoveAll(t => !t.IsActive && t.CreatedAt.AddDays(7) <= DateTime.UtcNow);
+        }
     }
 }

--- a/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Infrastructure/Data/Configuration/RefreshTokenConfiguration.cs
+++ b/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Infrastructure/Data/Configuration/RefreshTokenConfiguration.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using PersonalFinance.Services.UserManagement.Domain.Entities;
+
+namespace PersonalFinance.Services.UserManagement.Infrastructure.Data.Configuration
+{
+    public class RefreshTokenConfiguration : IEntityTypeConfiguration<RefreshToken>
+    {
+        public void Configure(EntityTypeBuilder<RefreshToken> builder)
+        {
+            builder.ToTable("RefreshTokens");
+
+            builder.HasKey(t => t.Id);
+
+            builder.Property(t => t.Token)
+                .IsRequired()
+                .HasMaxLength(200);
+
+            builder.Property(t => t.CreatedByIp)
+                .HasMaxLength(50);
+
+            builder.Property(t => t.RevokedByIp)
+                .HasMaxLength(50);
+
+            builder.Property(t => t.ReplacedByToken)
+                .HasMaxLength(200);
+
+            builder.HasIndex(t => t.UserId);
+        }
+    }
+}

--- a/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Infrastructure/Data/Configuration/UserConfiguration.cs
+++ b/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Infrastructure/Data/Configuration/UserConfiguration.cs
@@ -43,6 +43,9 @@ namespace PersonalFinance.Services.UserManagement.Infrastructure.Data.Configurat
                 .HasMaxLength(100)
                 .IsRequired();
 
+            builder.Property(u => u.GoogleId)
+                .HasMaxLength(100);
+
             builder.Property(u => u.PhoneNumber)
                 .HasMaxLength(20);
 
@@ -57,6 +60,15 @@ namespace PersonalFinance.Services.UserManagement.Infrastructure.Data.Configurat
                 .WithOne(ur => ur.User)
                 .HasForeignKey(ur => ur.UserId)
                 .OnDelete(DeleteBehavior.Cascade);
+
+            // One-to-many relationship with RefreshTokens using backing field
+            builder.HasMany(u => u.RefreshTokens)
+                .WithOne(rt => rt.User)
+                .HasForeignKey(rt => rt.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            builder.Navigation(u => u.RefreshTokens)
+                .UsePropertyAccessMode(PropertyAccessMode.Field);
 
             // Ignore domain events for EF Core
             builder.Ignore(u => u.DomainEvents);

--- a/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Infrastructure/Data/UserManagementDbContext.cs
+++ b/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Infrastructure/Data/UserManagementDbContext.cs
@@ -19,6 +19,7 @@ namespace PersonalFinance.Services.UserManagement.Infrastructure.Data
         public DbSet<UserProfile> UserProfiles => Set<UserProfile>();
         public DbSet<Role> Roles => Set<Role>();
         public DbSet<UserRole> UserRoles => Set<UserRole>();
+        public DbSet<RefreshToken> RefreshTokens => Set<RefreshToken>();
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -32,7 +33,7 @@ namespace PersonalFinance.Services.UserManagement.Infrastructure.Data
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
             base.OnConfiguring(optionsBuilder);
-            optionsBuilder.ConfigureWarnings(warnings => warnings.Throw(RelationalEventId.PendingModelChangesWarning));
+            optionsBuilder.ConfigureWarnings(warnings => warnings.Log(RelationalEventId.PendingModelChangesWarning));
         }
 
         private void ConfigureEntityFilters(ModelBuilder modelBuilder)
@@ -52,6 +53,10 @@ namespace PersonalFinance.Services.UserManagement.Infrastructure.Data
             // UserRole junction table filter
             modelBuilder.Entity<UserRole>()
                 .HasQueryFilter(ur => ur.User.IsActive && ur.Role.IsActive);
+
+            // RefreshToken follows User filter
+            modelBuilder.Entity<RefreshToken>()
+                .HasQueryFilter(rt => rt.User.IsActive);
         }
     }
 }

--- a/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Infrastructure/Services/TokenService.cs
+++ b/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Infrastructure/Services/TokenService.cs
@@ -1,5 +1,6 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
+using System.Security.Cryptography;
 using System.Text;
 
 using Microsoft.IdentityModel.Tokens;
@@ -51,6 +52,14 @@ namespace PersonalFinance.Services.UserManagement.Infrastructure.Services
             var token = tokenHandler.CreateToken(tokenDescriptor);
 
             return tokenHandler.WriteToken(token);
+        }
+
+        public string GenerateRefreshToken()
+        {
+            var randomNumber = new byte[64];
+            using var rng = RandomNumberGenerator.Create();
+            rng.GetBytes(randomNumber);
+            return Convert.ToBase64String(randomNumber);
         }
     }
 }

--- a/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Migrations/20260415184412_AddRefreshToken.Designer.cs
+++ b/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Migrations/20260415184412_AddRefreshToken.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using PersonalFinance.Services.UserManagement.Infrastructure.Data;
 
@@ -11,9 +12,11 @@ using PersonalFinance.Services.UserManagement.Infrastructure.Data;
 namespace PersonalFinance.Services.UserManagement.Migrations
 {
     [DbContext(typeof(UserManagementDbContext))]
-    partial class UserManagementDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260415184412_AddRefreshToken")]
+    partial class AddRefreshToken
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Migrations/20260415184412_AddRefreshToken.cs
+++ b/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/Migrations/20260415184412_AddRefreshToken.cs
@@ -1,0 +1,64 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PersonalFinance.Services.UserManagement.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRefreshToken : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "GoogleId",
+                table: "Users",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "RefreshTokens",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Token = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    ExpiresAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedByIp = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true),
+                    RevokedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    RevokedByIp = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true),
+                    ReplacedByToken = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    IsActive = table.Column<bool>(type: "bit", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RefreshTokens", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_RefreshTokens_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RefreshTokens_UserId",
+                table: "RefreshTokens",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "RefreshTokens");
+
+            migrationBuilder.DropColumn(
+                name: "GoogleId",
+                table: "Users");
+        }
+    }
+}

--- a/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/PersonalFinance.Services.UserManagement.csproj
+++ b/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/PersonalFinance.Services.UserManagement.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
+    <PackageReference Include="Google.Apis.Auth" Version="1.69.0" />
     <PackageReference Include="MassTransit" Version="8.5.1" />
     <PackageReference Include="MassTransit.AspNetCore" Version="7.3.1" />
     <PackageReference Include="MassTransit.RabbitMQ" Version="8.5.1" />

--- a/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/appsettings.json
+++ b/apps/dotnet-services/PersonalFinanceServices/src/Services/PersonalFinance.Services.UserManagement/appsettings.json
@@ -16,6 +16,9 @@
     "Audience": "PersonalFinance.Client",
     "ExpiryMinutes": 5
   },
+  "GoogleSettings": {
+    "ClientId": "13080223109-g7gdrv98jb4r35lngrcqoet9mp5k9n80.apps.googleusercontent.com"
+  },
   "Serilog": {
     "MinimumLevel": {
       "Default": "Debug",

--- a/apps/web/app/auth/AuthClient.tsx
+++ b/apps/web/app/auth/AuthClient.tsx
@@ -4,13 +4,20 @@ import { useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import {
-  LineChart,
-  ArrowRight,
-  Eye,
-  EyeOff,
-  ShieldCheck,
-  Zap,
+  LineChart as LineChartIcon,
+  ArrowRight as ArrowRightIcon,
+  Eye as EyeIcon,
+  EyeOff as EyeOffIcon,
+  ShieldCheck as ShieldCheckIcon,
+  Zap as ZapIcon,
 } from "lucide-react";
+
+const LineChart = LineChartIcon as any;
+const ArrowRight = ArrowRightIcon as any;
+const Eye = EyeIcon as any;
+const EyeOff = EyeOffIcon as any;
+const ShieldCheck = ShieldCheckIcon as any;
+const Zap = ZapIcon as any;
 import Image from "next/image";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -19,6 +26,9 @@ import { ThemeToggle } from "@/components/theme-toggle";
 import { RegisterModal } from "@/components/register-modal";
 import { authService } from "@/services/auth";
 import { useAuthStore } from "@/store/useAuthStore";
+import { useEffect } from "react";
+
+const GOOGLE_CLIENT_ID = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID || "";
 
 export default function AuthClient() {
   const router = useRouter();
@@ -69,6 +79,57 @@ export default function AuthClient() {
       setIsLoading(false);
     }
   };
+
+  const handleGoogleLogin = async (response: any) => {
+    setError(null);
+    setIsLoading(true);
+
+    try {
+      const res = await authService.googleLogin(response.credential);
+
+      if (res.success && res.data) {
+        login(res.data.accessToken, res.data.user);
+        authService.storeToken(res.data.accessToken, res.data.refreshToken);
+
+        const target =
+          redirectUrl ||
+          (res.data.user.roles?.includes("Admin")
+            ? "/dashboard"
+            : "/my/dashboard");
+
+        router.push(target);
+      } else {
+        setError(res.message || "Google login failed");
+      }
+    } catch (err: any) {
+      setError(err.response?.data?.message || err.message || "Google login failed");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    /* global google */
+    if (typeof window !== "undefined" && (window as any).google && GOOGLE_CLIENT_ID) {
+      const google = (window as any).google;
+      google.accounts.id.initialize({
+        client_id: GOOGLE_CLIENT_ID,
+        callback: handleGoogleLogin,
+      });
+
+      google.accounts.id.renderButton(
+        document.getElementById("google-button"),
+        {
+          theme: "outline",
+          size: "large",
+          width: "100%",
+          shape: "rectangular",
+          text: "continue_with",
+          logo_alignment: "left"
+        }
+      );
+    }
+  }, [GOOGLE_CLIENT_ID]);
 
   return (
     <div className="min-h-screen flex selection:bg-indigo-500 selection:text-white">
@@ -226,6 +287,8 @@ export default function AuthClient() {
               </span>
             </div>
           </div>
+
+          <div id="google-button" className="w-full flex justify-center" />
 
           <div className="flex flex-col gap-4 text-center">
             <RegisterModal>

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Poppins } from "next/font/google";
 import "./globals.css";
+import Script from "next/script";
 import { ThemeProvider } from "@/components/theme-provider";
 import { Sidebar } from "@/components/layout/Sidebar";
 import { Header } from "@/components/layout/Header";
@@ -27,6 +28,7 @@ export default function RootLayout({
       <body
         className={`${poppins.variable} font-sans antialiased bg-background text-foreground h-full overflow-hidden`}
       >
+        <Script src="https://accounts.google.com/gsi/client" strategy="beforeInteractive" />
         <ThemeProvider
           attribute="class"
           defaultTheme="system"

--- a/apps/web/components/ui/label.tsx
+++ b/apps/web/components/ui/label.tsx
@@ -11,16 +11,18 @@ const labelVariants = cva(
 );
 
 const Label = React.forwardRef<
-  React.ElementRef<typeof LabelPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
-    VariantProps<typeof labelVariants>
->(({ className, ...props }, ref) => (
-  <LabelPrimitive.Root
-    ref={ref}
-    className={cn(labelVariants(), className)}
-    {...props}
-  />
-));
+  HTMLLabelElement,
+  React.LabelHTMLAttributes<HTMLLabelElement> & VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => {
+  const Comp = LabelPrimitive.Root as any;
+  return (
+    <Comp
+      ref={ref}
+      className={cn(labelVariants(), className)}
+      {...props}
+    />
+  );
+});
 Label.displayName = LabelPrimitive.Root.displayName;
 
 export { Label };

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,7 +19,6 @@
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
-    "@tailwindcss/postcss": "^4.2.2",
     "axios": "^1.14.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -39,6 +38,7 @@
     "zustand": "^5.0.12"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "^4.2.2",
     "@types/node": "^22.15.3",
     "@types/react": "19.1.0",
     "@types/react-dom": "19.1.1",

--- a/apps/web/services/api.ts
+++ b/apps/web/services/api.ts
@@ -25,14 +25,44 @@ api.interceptors.request.use(
 
 api.interceptors.response.use(
   (response) => response,
-  (error) => {
-    if (error.response?.status === 401) {
-      // Handle unauthorized - clear token and redirect to login
-      if (typeof window !== "undefined") {
-        localStorage.removeItem("auth_token");
-        localStorage.removeItem("auth_user");
+  async (error) => {
+    const originalRequest = error.config;
 
-        // Only auto-redirect if not already on auth page
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+
+      if (typeof window !== "undefined") {
+        const accessToken = localStorage.getItem("auth_token");
+        const refreshToken = localStorage.getItem("refresh_token");
+
+        if (accessToken && refreshToken) {
+          try {
+            // Import authService dynamically to avoid circular dependency
+            const { authService } = await import("./auth");
+            const response = await authService.refreshToken(
+              accessToken,
+              refreshToken
+            );
+
+            if (response.success && response.data) {
+              const newAccessToken = response.data.accessToken;
+              const newRefreshToken = response.data.refreshToken;
+
+              authService.storeToken(newAccessToken, newRefreshToken);
+
+              // Update header and retry
+              originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+              return api(originalRequest);
+            }
+          } catch (refreshError) {
+            console.error("Token refresh failed:", refreshError);
+            // If refresh fails, log out
+            const { authService } = await import("./auth");
+            authService.logout();
+          }
+        }
+
+        // Handle unauthorized - clear token and redirect to login
         const currentPath = window.location.pathname;
         if (!currentPath.startsWith("/auth") && currentPath !== "/") {
           window.location.href = `/auth?redirect=${encodeURIComponent(

--- a/apps/web/services/auth.ts
+++ b/apps/web/services/auth.ts
@@ -78,9 +78,37 @@ export const authService = {
     return response.data;
   },
 
-  storeToken: (token: string) => {
+  googleLogin: async (idToken: string): Promise<LoginApiResponse> => {
+    const response = await api.post(
+      "/api/Auth/google-login",
+      { idToken },
+      {
+        baseURL: GATEWAY_BASE_URL,
+      }
+    );
+    return response.data;
+  },
+
+  refreshToken: async (
+    accessToken: string,
+    refreshToken: string
+  ): Promise<LoginApiResponse> => {
+    const response = await api.post(
+      "/api/Auth/refresh",
+      { accessToken, refreshToken },
+      {
+        baseURL: GATEWAY_BASE_URL,
+      }
+    );
+    return response.data;
+  },
+
+  storeToken: (accessToken: string, refreshToken?: string) => {
     if (typeof window !== "undefined") {
-      localStorage.setItem("auth_token", token);
+      localStorage.setItem("auth_token", accessToken);
+      if (refreshToken) {
+        localStorage.setItem("refresh_token", refreshToken);
+      }
     }
   },
 
@@ -93,6 +121,13 @@ export const authService = {
   getToken: (): string | null => {
     if (typeof window !== "undefined") {
       return localStorage.getItem("auth_token");
+    }
+    return null;
+  },
+
+  getRefreshToken: (): string | null => {
+    if (typeof window !== "undefined") {
+      return localStorage.getItem("refresh_token");
     }
     return null;
   },
@@ -118,6 +153,7 @@ export const authService = {
   logout: () => {
     if (typeof window !== "undefined") {
       localStorage.removeItem("auth_token");
+      localStorage.removeItem("refresh_token");
       localStorage.removeItem("auth_user");
     }
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1981,7 +1981,6 @@
         "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.2.4",
-        "@tailwindcss/postcss": "^4.2.2",
         "axios": "^1.14.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -2001,6 +2000,7 @@
         "zustand": "^5.0.12"
       },
       "devDependencies": {
+        "@tailwindcss/postcss": "^4.2.2",
         "@types/node": "^22.15.3",
         "@types/react": "19.1.0",
         "@types/react-dom": "19.1.1",
@@ -7825,6 +7825,7 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -10216,6 +10217,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
       "integrity": "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
         "enhanced-resolve": "^5.19.0",
@@ -10230,6 +10232,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -10238,6 +10241,7 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -10269,6 +10273,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -10288,6 +10293,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -10307,6 +10313,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -10326,6 +10333,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -10345,6 +10353,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -10364,6 +10373,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -10383,6 +10393,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -10402,6 +10413,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -10421,6 +10433,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -10440,6 +10453,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -10455,12 +10469,14 @@
     "node_modules/@tailwindcss/node/node_modules/tailwindcss": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
-      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q=="
+      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
+      "dev": true
     },
     "node_modules/@tailwindcss/oxide": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.2.tgz",
       "integrity": "sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==",
+      "dev": true,
       "engines": {
         "node": ">= 20"
       },
@@ -10486,6 +10502,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -10501,6 +10518,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -10516,6 +10534,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -10531,6 +10550,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -10546,6 +10566,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -10561,6 +10582,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -10576,6 +10598,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -10591,6 +10614,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -10606,6 +10630,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -10629,6 +10654,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "optional": true,
       "dependencies": {
         "@emnapi/core": "^1.8.1",
@@ -10649,6 +10675,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -10664,6 +10691,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -10676,6 +10704,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.2.2.tgz",
       "integrity": "sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ==",
+      "dev": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "@tailwindcss/node": "4.2.2",
@@ -10688,6 +10717,7 @@
       "version": "8.5.9",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
       "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -10714,7 +10744,8 @@
     "node_modules/@tailwindcss/postcss/node_modules/tailwindcss": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
-      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q=="
+      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
+      "dev": true
     },
     "node_modules/@turbo/darwin-64": {
       "version": "2.9.6",
@@ -13207,6 +13238,7 @@
       "version": "5.20.1",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
       "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.3.0"
@@ -15450,6 +15482,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "devOptional": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -16246,6 +16279,7 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
@@ -20819,6 +20853,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
       "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       },


### PR DESCRIPTION
- Implement Google login flow and user registration (backend)
- Add refresh token issuance, rotation, and persistence
- Update User entity for GoogleId and refresh tokens
- Add endpoints for Google login and token refresh
- Add EF Core config and migrations for refresh tokens
- Integrate Google One Tap login in frontend UI
- Store and use refresh tokens in frontend auth flow
- Auto-refresh JWT on 401 via Axios interceptor
- Refactor authService and minor UI improvements
- Update dependencies and config for Google OAuth